### PR TITLE
3.8 update

### DIFF
--- a/MoreCheckmarks.cs
+++ b/MoreCheckmarks.cs
@@ -747,12 +747,6 @@ namespace MoreCheckmarks
                         continue;
                     }
 
-                    // Skip if place of fame (unimplemented)
-                    if (ad.Template.Name.Equals("Place of fame"))
-                    {
-                        continue;
-                    }
-
                     // Skip if the area has no future upgrade
                     if (ad.Status == EFT.Hideout.EAreaStatus.NoFutureUpgrades)
                     {
@@ -856,6 +850,7 @@ namespace MoreCheckmarks
         public static bool GetNeededCraft(string itemTemplateID, ref string tooltip, bool needTooltip = true)
         {
             bool required = false;
+            bool gotTooltip = false;
             try
             {
                 HideoutClass hideoutInstance = Comfort.Common.Singleton<HideoutClass>.Instance;
@@ -863,12 +858,6 @@ namespace MoreCheckmarks
                 {
                     // Skip if don't have area data
                     if (ad == null || ad.Template == null || ad.Template.Name == null)
-                    {
-                        continue;
-                    }
-
-                    // Skip if place of fame (unimplemented)
-                    if (ad.Template.Name.Equals("Place of fame"))
                     {
                         continue;
                     }
@@ -924,6 +913,7 @@ namespace MoreCheckmarks
                                         {
                                             if (productionEndProductByID.TryGetValue(productionData._id, out string product))
                                             {
+                                                gotTooltip = true;
                                                 if (!areaNameAdded)
                                                 {
                                                     tooltip += "\n  " + ad.Template.Name.Localized();
@@ -948,7 +938,7 @@ namespace MoreCheckmarks
                 MoreCheckmarksMod.LogError("Failed to get whether item "+itemTemplateID+" was needed for crafting: "+ex.Message);
             }
 
-            return required;
+            return required && gotTooltip;
         }
 
         public static bool IsQuestItem(IEnumerable<QuestDataClass> quests, string templateID)

--- a/MoreCheckmarks.cs
+++ b/MoreCheckmarks.cs
@@ -21,13 +21,13 @@ using Comfort.Common;
 
 // UPDATE: Find these GClasses
 // We want to get access to the list of availabe loot item actions when we look at loose loot so we can change color of "Take" action
-// GClass1726 has static method GetAvailableActions(GamePlayerOwner owner, [CanBeNull] GInterface85 interactive) to get list of actions available for the interactive
-// This calls GClass1726.smethod_3 if the interactive is a LootItem
-// This returns an instance of GClass2805 which has a list field "Actions" containing all available actions of type GClass2804
-// GClass2804.Name will be directly used as the string that will be displayed in the list, so we set it to a TMPro string with correct color and bold
+// GetActionsClass has static method GetAvailableActions(GamePlayerOwner owner, [CanBeNull] GInterface102 interactive) to get list of actions available for the interactive
+// This calls GetActionsClass.smethod_4 if the interactive is a LootItem
+// This returns an instance of GClass3008 which has a list field "Actions" containing all available actions of type GClass3007
+// GClass3007.Name will be directly used as the string that will be displayed in the list, so we set it to a TMPro string with correct color and bold
 using InteractionController = GetActionsClass;
-using InteractionInstance = GClass3012;
-using Action = GClass3011;
+using InteractionInstance = GClass3008;
+using Action = GClass3007;
 using EFT.Hideout;
 
 namespace MoreCheckmarks
@@ -46,7 +46,7 @@ namespace MoreCheckmarks
         // BepinEx
         public const string pluginGuid = "VIP.TommySoucy.MoreCheckmarks";
         public const string pluginName = "MoreCheckmarks";
-        public const string pluginVersion = "1.5.9";
+        public const string pluginVersion = "1.5.10";
 
         // Config settings
         public static bool fulfilledAnyCanBeUpgraded = false;
@@ -564,14 +564,14 @@ namespace MoreCheckmarks
                 }
             }
 
-            /*LogInfo("\tProductions");
+            LogInfo("\tProductions");
             JArray productionData = JArray.Parse(RequestHandler.GetJson("/MoreCheckmarksRoutes/productions", false));
             productionEndProductByID.Clear();
 
             for (int i = 0; i < productionData.Count; ++i)
             {
                 productionEndProductByID.Add(productionData[i]["_id"].ToString(), productionData[i]["endProduct"].ToString());
-            }*/
+            }
         }
 
         private bool StringJArrayContainsString(JArray arr, string s)
@@ -970,7 +970,7 @@ namespace MoreCheckmarks
                         {
                             if (quest.Template.Conditions != null)
                             {
-                                foreach (KeyValuePair<EQuestStatus, GClass3373> keyValuePair in quest.Template.Conditions)
+                                foreach (KeyValuePair<EQuestStatus, GClass3368> keyValuePair in quest.Template.Conditions)
                                 {
                                     if (keyValuePair.Key == EQuestStatus.AvailableForFinish)
                                     {
@@ -1336,12 +1336,12 @@ namespace MoreCheckmarks
                         {
                             if (questDataClass.Status == EQuestStatus.Started && questDataClass.Template != null)
                             {
-                                // UPDATE: Look for the type used in QuestDataClass's Template var of type RawGClass1249
+                                // UPDATE: Look for the type used in QuestDataClass's Template var of type RawQuestClass
                                 // with QuestConditionsList, for the value
-                                foreach (KeyValuePair<EQuestStatus, GClass3373> kvp in questDataClass.Template.Conditions)
+                                foreach (KeyValuePair<EQuestStatus, GClass3368> kvp in questDataClass.Template.Conditions)
                                 {
                                     EQuestStatus equestStatus;
-                                    GClass3373 gclass;
+                                    GClass3368 gclass;
                                     kvp.Deconstruct(out equestStatus, out gclass);
                                     foreach (Condition condition in gclass)
                                     {

--- a/MoreCheckmarks.cs
+++ b/MoreCheckmarks.cs
@@ -25,9 +25,9 @@ using Comfort.Common;
 // This calls GClass1726.smethod_3 if the interactive is a LootItem
 // This returns an instance of GClass2805 which has a list field "Actions" containing all available actions of type GClass2804
 // GClass2804.Name will be directly used as the string that will be displayed in the list, so we set it to a TMPro string with correct color and bold
-using InteractionController = GClass1726;
-using InteractionInstance = GClass2805;
-using Action = GClass2804;
+using InteractionController = GetActionsClass;
+using InteractionInstance = GClass3012;
+using Action = GClass3011;
 using EFT.Hideout;
 
 namespace MoreCheckmarks
@@ -127,15 +127,15 @@ namespace MoreCheckmarks
             questDataCompleteByItemTemplateID.Clear();
             neededCompleteItemsByQuest.Clear();
 
-            for (int i=0; i<questData.Count; ++i)
+            for (int i = 0; i < questData.Count; ++i)
             {
                 JArray availableForFinishConditions = questData[i]["conditions"]["AvailableForFinish"] as JArray;
-                for(int j=0; j< availableForFinishConditions.Count; ++j)
+                for (int j = 0; j < availableForFinishConditions.Count; ++j)
                 {
-                    if (availableForFinishConditions[j]["_parent"].ToString().Equals("HandoverItem"))
+                    if (availableForFinishConditions[j]["conditionType"].ToString().Equals("HandoverItem"))
                     {
-                        JArray targets = availableForFinishConditions[j]["_props"]["target"] as JArray;
-                        for (int k = 0; k< targets.Count; ++k)
+                        JArray targets = availableForFinishConditions[j]["target"] as JArray;
+                        for (int k = 0; k < targets.Count; ++k)
                         {
                             if (questDataCompleteByItemTemplateID.TryGetValue(targets[k].ToString(), out QuestPair quests))
                             {
@@ -143,53 +143,53 @@ namespace MoreCheckmarks
                                 {
                                     quests.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
                                 }
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 quests.count += parsedValue;
                             }
                             else
                             {
                                 QuestPair newPair = new QuestPair();
                                 newPair.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 newPair.count = parsedValue;
                                 questDataCompleteByItemTemplateID.Add(targets[k].ToString(), newPair);
                             }
 
-                            if(neededCompleteItemsByQuest.TryGetValue(questData[i]["_id"].ToString(), out Dictionary<string, int> items))
+                            if (neededCompleteItemsByQuest.TryGetValue(questData[i]["_id"].ToString(), out Dictionary<string, int> items))
                             {
                                 if (!items.ContainsKey(targets[k].ToString()))
                                 {
                                     items.Add(targets[k].ToString(), 0);
                                 }
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 items[targets[k].ToString()] += parsedValue;
                             }
                             else
                             {
                                 Dictionary<string, int> newDict = new Dictionary<string, int>();
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 newDict.Add(targets[k].ToString(), parsedValue);
                                 neededCompleteItemsByQuest.Add(questData[i]["_id"].ToString(), newDict);
                             }
                         }
                     }
 
-                    if (availableForFinishConditions[j]["_parent"].ToString().Equals("FindItem"))
+                    if (availableForFinishConditions[j]["conditionType"].ToString().Equals("FindItem"))
                     {
-                        JArray targets = availableForFinishConditions[j]["_props"]["target"] as JArray;
-                        for (int k = 0; k< targets.Count; ++k)
+                        JArray targets = availableForFinishConditions[j]["target"] as JArray;
+                        for (int k = 0; k < targets.Count; ++k)
                         {
                             // Check if there is a hand in item condition for the same item and at least the same count
                             // If so skip this, we will count the hand in instead
                             bool foundInHandin = false;
                             for (int l = 0; l < availableForFinishConditions.Count; ++l)
                             {
-                                if (availableForFinishConditions[l]["_parent"].ToString().Equals("HandoverItem"))
+                                if (availableForFinishConditions[l]["conditionType"].ToString().Equals("HandoverItem"))
                                 {
-                                    JArray handInTargets = availableForFinishConditions[l]["_props"]["target"] as JArray;
-                                    if (handInTargets != null && StringJArrayContainsString(handInTargets, targets[k].ToString()) && 
-                                        (!int.TryParse(availableForFinishConditions[l]["_props"]["value"].ToString(), out int parsedValue) || 
-                                         !int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int currentParsedValue) || 
+                                    JArray handInTargets = availableForFinishConditions[l]["target"] as JArray;
+                                    if (handInTargets != null && StringJArrayContainsString(handInTargets, targets[k].ToString()) &&
+                                        (!int.TryParse(availableForFinishConditions[l]["value"].ToString(), out int parsedValue) ||
+                                         !int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int currentParsedValue) ||
                                          parsedValue == currentParsedValue))
                                     {
                                         foundInHandin = true;
@@ -208,14 +208,14 @@ namespace MoreCheckmarks
                                 {
                                     quests.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
                                 }
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 quests.count += parsedValue;
                             }
                             else
                             {
                                 QuestPair newPair = new QuestPair();
                                 newPair.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 newPair.count = parsedValue;
                                 questDataCompleteByItemTemplateID.Add(targets[k].ToString(), newPair);
                             }
@@ -226,23 +226,23 @@ namespace MoreCheckmarks
                                 {
                                     items.Add(targets[k].ToString(), 0);
                                 }
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 items[targets[k].ToString()] += parsedValue;
                             }
                             else
                             {
                                 Dictionary<string, int> newDict = new Dictionary<string, int>();
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 newDict.Add(targets[k].ToString(), parsedValue);
                                 neededCompleteItemsByQuest.Add(questData[i]["_id"].ToString(), newDict);
                             }
                         }
                     }
 
-                    if (availableForFinishConditions[j]["_parent"].ToString().Equals("LeaveItemAtLocation"))
+                    if (availableForFinishConditions[j]["conditionType"].ToString().Equals("LeaveItemAtLocation"))
                     {
-                        JArray targets = availableForFinishConditions[j]["_props"]["target"] as JArray;
-                        for (int k = 0; k< targets.Count; ++k)
+                        JArray targets = availableForFinishConditions[j]["target"] as JArray;
+                        for (int k = 0; k < targets.Count; ++k)
                         {
                             if (questDataCompleteByItemTemplateID.TryGetValue(targets[k].ToString(), out QuestPair quests))
                             {
@@ -250,14 +250,14 @@ namespace MoreCheckmarks
                                 {
                                     quests.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
                                 }
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 quests.count += parsedValue;
                             }
                             else
                             {
                                 QuestPair newPair = new QuestPair();
                                 newPair.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 newPair.count = parsedValue;
                                 questDataCompleteByItemTemplateID.Add(targets[k].ToString(), newPair);
                             }
@@ -268,23 +268,23 @@ namespace MoreCheckmarks
                                 {
                                     items.Add(targets[k].ToString(), 0);
                                 }
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 items[targets[k].ToString()] += parsedValue;
                             }
                             else
                             {
                                 Dictionary<string, int> newDict = new Dictionary<string, int>();
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 newDict.Add(targets[k].ToString(), parsedValue);
                                 neededCompleteItemsByQuest.Add(questData[i]["_id"].ToString(), newDict);
                             }
                         }
                     }
 
-                    if (availableForFinishConditions[j]["_parent"].ToString().Equals("PlaceBeacon"))
+                    if (availableForFinishConditions[j]["conditionType"].ToString().Equals("PlaceBeacon"))
                     {
-                        JArray targets = availableForFinishConditions[j]["_props"]["target"] as JArray;
-                        for (int k = 0; k< targets.Count; ++k)
+                        JArray targets = availableForFinishConditions[j]["target"] as JArray;
+                        for (int k = 0; k < targets.Count; ++k)
                         {
                             if (questDataCompleteByItemTemplateID.TryGetValue(targets[k].ToString(), out QuestPair quests))
                             {
@@ -292,14 +292,14 @@ namespace MoreCheckmarks
                                 {
                                     quests.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
                                 }
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 quests.count += parsedValue;
                             }
                             else
                             {
                                 QuestPair newPair = new QuestPair();
                                 newPair.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 newPair.count = parsedValue;
                                 questDataCompleteByItemTemplateID.Add(targets[k].ToString(), newPair);
                             }
@@ -310,13 +310,13 @@ namespace MoreCheckmarks
                                 {
                                     items.Add(targets[k].ToString(), 0);
                                 }
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 items[targets[k].ToString()] += parsedValue;
                             }
                             else
                             {
                                 Dictionary<string, int> newDict = new Dictionary<string, int>();
-                                int.TryParse(availableForFinishConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForFinishConditions[j]["value"].ToString(), out int parsedValue);
                                 newDict.Add(targets[k].ToString(), parsedValue);
                                 neededCompleteItemsByQuest.Add(questData[i]["_id"].ToString(), newDict);
                             }
@@ -325,12 +325,12 @@ namespace MoreCheckmarks
                 }
 
                 JArray availableForStartConditions = questData[i]["conditions"]["AvailableForStart"] as JArray;
-                for(int j=0; j< availableForStartConditions.Count; ++j)
+                for (int j = 0; j < availableForStartConditions.Count; ++j)
                 {
-                    if (availableForStartConditions[j]["_parent"].ToString().Equals("HandoverItem"))
+                    if (availableForStartConditions[j]["conditionType"].ToString().Equals("HandoverItem"))
                     {
-                        JArray targets = availableForStartConditions[j]["_props"]["target"] as JArray;
-                        for (int k = 0; k< targets.Count; ++k)
+                        JArray targets = availableForStartConditions[j]["target"] as JArray;
+                        for (int k = 0; k < targets.Count; ++k)
                         {
                             if (questDataStartByItemTemplateID.TryGetValue(targets[k].ToString(), out QuestPair quests))
                             {
@@ -338,14 +338,14 @@ namespace MoreCheckmarks
                                 {
                                     quests.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
                                 }
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 quests.count += parsedValue;
                             }
                             else
                             {
                                 QuestPair newPair = new QuestPair();
                                 newPair.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 newPair.count = parsedValue;
                                 questDataStartByItemTemplateID.Add(targets[k].ToString(), newPair);
                             }
@@ -356,35 +356,35 @@ namespace MoreCheckmarks
                                 {
                                     items.Add(targets[k].ToString(), 0);
                                 }
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 items[targets[k].ToString()] += parsedValue;
                             }
                             else
                             {
                                 Dictionary<string, int> newDict = new Dictionary<string, int>();
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 newDict.Add(targets[k].ToString(), parsedValue);
                                 neededStartItemsByQuest.Add(questData[i]["_id"].ToString(), newDict);
                             }
                         }
                     }
 
-                    if (availableForStartConditions[j]["_parent"].ToString().Equals("FindItem"))
+                    if (availableForStartConditions[j]["conditionType"].ToString().Equals("FindItem"))
                     {
-                        JArray targets = availableForStartConditions[j]["_props"]["target"] as JArray;
-                        for (int k = 0; k< targets.Count; ++k)
+                        JArray targets = availableForStartConditions[j]["target"] as JArray;
+                        for (int k = 0; k < targets.Count; ++k)
                         {
                             // Check if there is a hand in item condition for the same item and at least the same count
                             // If so skip this, we will count the hand in instead
                             bool foundInHandin = false;
                             for (int l = 0; l < availableForStartConditions.Count; ++l)
                             {
-                                if (availableForStartConditions[l]["_parent"].ToString().Equals("HandoverItem"))
+                                if (availableForStartConditions[l]["conditionType"].ToString().Equals("HandoverItem"))
                                 {
-                                    JArray handInTargets = availableForStartConditions[l]["_props"]["target"] as JArray;
+                                    JArray handInTargets = availableForStartConditions[l]["target"] as JArray;
                                     if (handInTargets != null && StringJArrayContainsString(handInTargets, targets[k].ToString()) &&
-                                        (!int.TryParse(availableForStartConditions[l]["_props"]["value"].ToString(), out int parsedValue) ||
-                                         !int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int currentParsedValue) ||
+                                        (!int.TryParse(availableForStartConditions[l]["value"].ToString(), out int parsedValue) ||
+                                         !int.TryParse(availableForStartConditions[j]["value"].ToString(), out int currentParsedValue) ||
                                          parsedValue == currentParsedValue))
                                     {
                                         foundInHandin = true;
@@ -403,14 +403,14 @@ namespace MoreCheckmarks
                                 {
                                     quests.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
                                 }
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 quests.count += parsedValue;
                             }
                             else
                             {
                                 QuestPair newPair = new QuestPair();
                                 newPair.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 newPair.count = parsedValue;
                                 questDataStartByItemTemplateID.Add(targets[k].ToString(), newPair);
                             }
@@ -421,23 +421,23 @@ namespace MoreCheckmarks
                                 {
                                     items.Add(targets[k].ToString(), 0);
                                 }
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 items[targets[k].ToString()] += parsedValue;
                             }
                             else
                             {
                                 Dictionary<string, int> newDict = new Dictionary<string, int>();
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 newDict.Add(targets[k].ToString(), parsedValue);
                                 neededStartItemsByQuest.Add(questData[i]["_id"].ToString(), newDict);
                             }
                         }
                     }
 
-                    if (availableForStartConditions[j]["_parent"].ToString().Equals("LeaveItemAtLocation"))
+                    if (availableForStartConditions[j]["conditionType"].ToString().Equals("LeaveItemAtLocation"))
                     {
-                        JArray targets = availableForStartConditions[j]["_props"]["target"] as JArray;
-                        for (int k = 0; k< targets.Count; ++k)
+                        JArray targets = availableForStartConditions[j]["target"] as JArray;
+                        for (int k = 0; k < targets.Count; ++k)
                         {
                             if (questDataStartByItemTemplateID.TryGetValue(targets[k].ToString(), out QuestPair quests))
                             {
@@ -445,14 +445,14 @@ namespace MoreCheckmarks
                                 {
                                     quests.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
                                 }
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 quests.count += parsedValue;
                             }
                             else
                             {
                                 QuestPair newPair = new QuestPair();
                                 newPair.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 newPair.count = parsedValue;
                                 questDataStartByItemTemplateID.Add(targets[k].ToString(), newPair);
                             }
@@ -463,23 +463,23 @@ namespace MoreCheckmarks
                                 {
                                     items.Add(targets[k].ToString(), 0);
                                 }
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 items[targets[k].ToString()] += parsedValue;
                             }
                             else
                             {
                                 Dictionary<string, int> newDict = new Dictionary<string, int>();
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 newDict.Add(targets[k].ToString(), parsedValue);
                                 neededStartItemsByQuest.Add(questData[i]["_id"].ToString(), newDict);
                             }
                         }
                     }
 
-                    if (availableForStartConditions[j]["_parent"].ToString().Equals("PlaceBeacon"))
+                    if (availableForStartConditions[j]["conditionType"].ToString().Equals("PlaceBeacon"))
                     {
-                        JArray targets = availableForStartConditions[j]["_props"]["target"] as JArray;
-                        for (int k = 0; k< targets.Count; ++k)
+                        JArray targets = availableForStartConditions[j]["target"] as JArray;
+                        for (int k = 0; k < targets.Count; ++k)
                         {
                             if (questDataStartByItemTemplateID.TryGetValue(targets[k].ToString(), out QuestPair quests))
                             {
@@ -487,14 +487,14 @@ namespace MoreCheckmarks
                                 {
                                     quests.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
                                 }
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 quests.count += parsedValue;
                             }
                             else
                             {
                                 QuestPair newPair = new QuestPair();
                                 newPair.questData.Add(questData[i]["name"].ToString(), questData[i]["QuestName"].ToString());
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 newPair.count = parsedValue;
                                 questDataStartByItemTemplateID.Add(targets[k].ToString(), newPair);
                             }
@@ -505,13 +505,13 @@ namespace MoreCheckmarks
                                 {
                                     items.Add(targets[k].ToString(), 0);
                                 }
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 items[targets[k].ToString()] += parsedValue;
                             }
                             else
                             {
                                 Dictionary<string, int> newDict = new Dictionary<string, int>();
-                                int.TryParse(availableForStartConditions[j]["_props"]["value"].ToString(), out int parsedValue);
+                                int.TryParse(availableForStartConditions[j]["value"].ToString(), out int parsedValue);
                                 newDict.Add(targets[k].ToString(), parsedValue);
                                 neededStartItemsByQuest.Add(questData[i]["_id"].ToString(), newDict);
                             }
@@ -564,14 +564,14 @@ namespace MoreCheckmarks
                 }
             }
 
-            LogInfo("\tProductions");
+            /*LogInfo("\tProductions");
             JArray productionData = JArray.Parse(RequestHandler.GetJson("/MoreCheckmarksRoutes/productions", false));
             productionEndProductByID.Clear();
 
             for (int i = 0; i < productionData.Count; ++i)
             {
                 productionEndProductByID.Add(productionData[i]["_id"].ToString(), productionData[i]["endProduct"].ToString());
-            }
+            }*/
         }
 
         private bool StringJArrayContainsString(JArray arr, string s)
@@ -714,7 +714,7 @@ namespace MoreCheckmarks
                     // UPDATE: This is to know when a new profile is selected so we can load up to date data
                     // We want to do this when client makes request "/client/game/profile/select"
                     // Look for that string in dnspy, this creates a callback with a method_0, that is the method we want to postfix
-                    ProfileSelector = assemblies[i].GetType("Class235").GetNestedType("Class1213", BindingFlags.NonPublic);
+                    ProfileSelector = assemblies[i].GetType("Class263").GetNestedType("Class1291", BindingFlags.Public);
                 }
             }
 
@@ -724,7 +724,7 @@ namespace MoreCheckmarks
             harmony.PatchAll();
 
             // Manual patch
-            MethodInfo profileSelectorOriginal = ProfileSelector.GetMethod("method_0", BindingFlags.NonPublic | BindingFlags.Instance);
+            MethodInfo profileSelectorOriginal = ProfileSelector.GetMethod("method_0", BindingFlags.Public | BindingFlags.Instance);
             MethodInfo profileSelectorPostfix = typeof(ProfileSelectionPatch).GetMethod("Postfix", BindingFlags.NonPublic | BindingFlags.Static);
 
             harmony.Patch(profileSelectorOriginal, null, new HarmonyMethod(profileSelectorPostfix));
@@ -906,7 +906,7 @@ namespace MoreCheckmarks
                     if (currentStage.Production != null && currentStage.Production.Data != null)
                     {
                         bool areaNameAdded = false;
-                        foreach (GClass1789 productionData in currentStage.Production.Data)
+                        foreach (GClass1922 productionData in currentStage.Production.Data)
                         {
                             Requirement[] requirements = productionData.requirements;
 
@@ -968,14 +968,22 @@ namespace MoreCheckmarks
                             quest.Status == EQuestStatus.Started &&
                             quest.Template != null && quest.Template.Conditions != null && quest.Template.Conditions.ContainsKey(EQuestStatus.AvailableForFinish))
                         {
-                            IEnumerable<ConditionItem> conditions = quest.Template.GetConditions<ConditionItem>(EQuestStatus.AvailableForFinish);
-                            if (conditions != null)
+                            if (quest.Template.Conditions != null)
                             {
-                                foreach (ConditionItem condition in conditions)
+                                foreach (KeyValuePair<EQuestStatus, GClass3373> keyValuePair in quest.Template.Conditions)
                                 {
-                                    if (condition != null && condition.target != null && condition.target.Contains(templateID))
+                                    if (keyValuePair.Key == EQuestStatus.AvailableForFinish)
                                     {
-                                        return true;
+                                        foreach (Condition condition in keyValuePair.Value)
+                                        {
+                                            if (condition is ConditionItem conditionItem)
+                                            {
+                                                if (conditionItem.target != null && conditionItem.target.Contains(templateID))
+                                                {
+                                                    return true;
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -1322,25 +1330,25 @@ namespace MoreCheckmarks
                     }
                     else // Don't include future quests, do as vanilla
                     {
-                        RawQuestClass rawQuestClass = null;
+                        RawQuestClass RawQuestClass = null;
                         ConditionItem conditionItem = null;
                         foreach (QuestDataClass questDataClass in profile.QuestsData)
                         {
                             if (questDataClass.Status == EQuestStatus.Started && questDataClass.Template != null)
                             {
-                                // UPDATE: Look for the type used in QuestDataClass's Template var of type RawQuestClass
+                                // UPDATE: Look for the type used in QuestDataClass's Template var of type RawGClass1249
                                 // with QuestConditionsList, for the value
-                                foreach (KeyValuePair<EQuestStatus, GClass3091> kvp in questDataClass.Template.Conditions)
+                                foreach (KeyValuePair<EQuestStatus, GClass3373> kvp in questDataClass.Template.Conditions)
                                 {
                                     EQuestStatus equestStatus;
-                                    GClass3091 gclass;
+                                    GClass3373 gclass;
                                     kvp.Deconstruct(out equestStatus, out gclass);
                                     foreach (Condition condition in gclass)
                                     {
                                         ConditionItem conditionItem2;
                                         if (!questDataClass.CompletedConditions.Contains(condition.id) && (conditionItem2 = (condition as ConditionItem)) != null && conditionItem2.target.Contains(item.TemplateId))
                                         {
-                                            rawQuestClass = questDataClass.Template;
+                                            RawQuestClass = questDataClass.Template;
                                             conditionItem = conditionItem2;
                                             break;
                                         }
@@ -1348,9 +1356,9 @@ namespace MoreCheckmarks
                                 }
                             }
                         }
-                        if (rawQuestClass != null)
+                        if (RawQuestClass != null)
                         {
-                            string arg = "<color=#dd831a>" + rawQuestClass.Name + "</color>";
+                            string arg = "<color=#dd831a>" + RawQuestClass.Name + "</color>";
                             if (item.QuestItem)
                             {
                                 gotQuest = true;
@@ -1471,7 +1479,7 @@ namespace MoreCheckmarks
     class AvailableActionsPatch
     {
         // This postfix will run after we get a list of all actions available to interact with the item we are pointing at
-        [HarmonyPatch(typeof(InteractionController), "smethod_3")]
+        [HarmonyPatch(typeof(InteractionController), "smethod_4")]
         static void Postfix(GamePlayerOwner owner, LootItem lootItem, ref InteractionInstance __result)
         {
             try
@@ -1596,20 +1604,20 @@ namespace MoreCheckmarks
     }
 
     [HarmonyPatch]
-    class QuestClassStatusPatch
+    class GClass1249StatusPatch
     {
         private static EQuestStatus preStatus;
 
         // This prefix will run before a quest's status has been set 
-        [HarmonyPatch(typeof(QuestClass), "set_QuestStatus")]
-        static void Prefix(QuestClass __instance)
+        [HarmonyPatch(typeof(GClass1249), "SetStatus")]
+        static void Prefix(GClass1249 __instance)
         {
             preStatus = __instance.QuestStatus;
         }
 
         // This postfix will run after a quest's status has been set 
-        [HarmonyPatch(typeof(QuestClass), "set_QuestStatus")]
-        static void Postfix(QuestClass __instance)
+        [HarmonyPatch(typeof(GClass1249), "SetStatus")]
+        static void Postfix(GClass1249 __instance)
         {
             if(__instance == null)
             {

--- a/MoreCheckmarksBackend/package.json
+++ b/MoreCheckmarksBackend/package.json
@@ -1,10 +1,10 @@
 {
     "name": "MoreCheckmarksBackend",
-    "version": "1.5.1",
+    "version": "1.5.10",
     "main": "src/MoreCheckmarksStaticRouter.js",
     "license": "MIT",
     "author": "VIP",
-    "akiVersion": "~3.5",
+    "akiVersion": "~3.8",
     "scripts": {
         "setup": "npm i",
         "build": "node ./packageBuild.ts"


### PR DESCRIPTION
This runs on the latest version for BE. GClass references might need to be updated for the final build.

Update all the **JArray** tokens for the new quest structure. Commented out the `/productions/` request to prevent errors as it is not in the server side mod for some reason? Not sure if this is intentional.

`IsQuestItem()` has been refactored to support 3.8. You might want to take an extra look at it to make sure I understood the intention of the method correctly.

The mod starts without any errors and I see all the values as I think intended. However I haven't delved too into the code so I think it'd be easier for you to verify that all is working as it should.