### PR TITLE
FEATURE set checkmark color to fulfilled for quest item when `includeFutureQuests`

### DIFF
--- a/MoreCheckmarks.cs
+++ b/MoreCheckmarks.cs
@@ -1219,6 +1219,41 @@ namespace MoreCheckmarks
                             }
                         }
                     }
+                    else if (currentNeeded == 0) // quest item
+                    {
+                        if (MoreCheckmarksMod.includeFutureQuests)
+                        {
+                            if (startQuests != null)
+                            {
+                                int totalNeeded = startQuests.count;
+                                if (possessedQuestCount >= totalNeeded)
+                                {
+                                    SetCheckmark(__instance, ____questIconImage, ____foundInRaidSprite, MoreCheckmarksMod.fulfilledColor);
+                                }
+                                else
+                                {
+                                    SetCheckmark(__instance, ____questIconImage, ____foundInRaidSprite, MoreCheckmarksMod.colors[currentNeeded]);
+                                }
+                            }
+                            if (completeQuests != null)
+                            {
+                                int totalNeeded = completeQuests.count;
+                                if (possessedQuestCount >= totalNeeded)
+                                {
+                                    SetCheckmark(__instance, ____questIconImage, ____foundInRaidSprite, MoreCheckmarksMod.fulfilledColor);
+                                }
+                                else
+                                {
+                                    SetCheckmark(__instance, ____questIconImage, ____foundInRaidSprite, MoreCheckmarksMod.colors[currentNeeded]);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // TODO: set to `fulfilledColor` when `includeFutureQuests` is `false` and condition is fulfilled
+                            SetCheckmark(__instance, ____questIconImage, ____foundInRaidSprite, MoreCheckmarksMod.colors[currentNeeded]);
+                        }
+                    }
                     else // Not area, just set color
                     {
                         SetCheckmark(__instance, ____questIconImage, ____foundInRaidSprite, MoreCheckmarksMod.colors[currentNeeded]);

--- a/MoreCheckmarks.cs
+++ b/MoreCheckmarks.cs
@@ -804,10 +804,10 @@ namespace MoreCheckmarks
             harmony.Patch(profileSelectorOriginal, null, new HarmonyMethod(profileSelectorPostfix));
         }
 
-        public static NeededStruct GetNeeded(string itemTemplateID, ref List<string> areaNames)
+        public static NeededStruct GetNeeded(string itemTemplateID, ref List<string> areaNames, int possessedCount)
         {
             NeededStruct neededStruct = new NeededStruct();
-            neededStruct.possessedCount = 0;
+            neededStruct.possessedCount = possessedCount;
             neededStruct.requiredCount = 0;
 
             try
@@ -869,12 +869,16 @@ namespace MoreCheckmarks
                                         string requirementTemplate = itemRequirement.TemplateId;
                                         if (itemTemplateID == requirementTemplate)
                                         {
+                                            // if (itemTemplateID == "5e2af22086f7746d3f3c33fa" || itemTemplateID == "619cbf476b8a1b37a54eebf8") {
+                                            //     MoreCheckmarksMod.LogInfo("required: " + itemRequirement.IntCount + ", have: " + itemRequirement.UserItemsCount + ", fulfill: " + requirement.Fulfilled);
+                                            // }
+                                            
                                             // Sum up the total amount of this item required in entire hideout and update possessed amount
                                             neededStruct.requiredCount += itemRequirement.IntCount;
-                                            neededStruct.possessedCount = itemRequirement.UserItemsCount;
+                                            // neededStruct.possessedCount = itemRequirement.UserItemsCount;
 
                                             // A requirement but already have the amount we need
-                                            if (requirement.Fulfilled)
+                                            if (neededStruct.possessedCount >= itemRequirement.IntCount)
                                             {
                                                 // Even if we have enough of this item to fulfill a requirement in one area
                                                 // we might still need it, and if thats the case we want to show that color, not fulfilled color, so you know you still need more of it
@@ -1139,7 +1143,7 @@ namespace MoreCheckmarks
 
                 // Get requirements
                 List<string> areaNames = new List<string>();
-                NeededStruct neededStruct = MoreCheckmarksMod.GetNeeded(item.TemplateId, ref areaNames);
+                NeededStruct neededStruct = MoreCheckmarksMod.GetNeeded(item.TemplateId, ref areaNames, possessedCount);
                 string craftTooltip = "";
                 bool craftRequired = MoreCheckmarksMod.showCraft && MoreCheckmarksMod.GetNeededCraft(item.TemplateId, ref craftTooltip);
                 MoreCheckmarksMod.questDataStartByItemTemplateID.TryGetValue(item.TemplateId, out MoreCheckmarksMod.QuestPair startQuests);
@@ -1588,7 +1592,7 @@ namespace MoreCheckmarks
                     if (action.Name.Equals("Take"))
                     {
                         List<string> nullAreaNames = null;
-                        NeededStruct neededStruct = MoreCheckmarksMod.GetNeeded(lootItem.TemplateId, ref nullAreaNames);
+                        NeededStruct neededStruct = MoreCheckmarksMod.GetNeeded(lootItem.TemplateId, ref nullAreaNames, 0);
                         string craftTooltip = "";
                         bool craftRequired = MoreCheckmarksMod.GetNeededCraft(lootItem.TemplateId, ref craftTooltip, false);
                         bool wishlist = ItemUiContext.Instance.IsInWishList(lootItem.TemplateId);


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/6ca1bdd1-4569-4112-b301-017ef64c0588)

after:

![image](https://github.com/user-attachments/assets/17ea70bf-2062-4353-bf88-3394f1d1c3af)

the `Shroud Mask` fulfilled the required number so it is marked with green.
---

im new to cs programming, im not quite sure what does `startQuests` mean.